### PR TITLE
Update ui component

### DIFF
--- a/app.json
+++ b/app.json
@@ -3,7 +3,7 @@
         "newArchEnabled": true,
         "name": "Platelet Dispatch",
         "slug": "platelet",
-        "version": "1.6.20",
+        "version": "1.6.21",
         "orientation": "portrait",
         "icon": "./assets/icon.png",
         "userInterfaceStyle": "automatic",
@@ -14,7 +14,7 @@
         },
         "assetBundlePatterns": ["**/*"],
         "android": {
-            "versionCode": 10620,
+            "versionCode": 10621,
             "adaptiveIcon": {
                 "foregroundImage": "./assets/adaptive-icon.png",
                 "backgroundColor": "#ffffff"
@@ -24,7 +24,7 @@
         "ios": {
             "supportsTablet": true,
             "bundleIdentifier": "app.platelet.platelet",
-            "buildNumber": "1.6.20",
+            "buildNumber": "1.6.21",
             "infoPlist": {
                 "ITSAppUsesNonExemptEncryption": false
             }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/datastore-storage-adapter": "^2.0.42",
-        "@aws-amplify/ui-react-native": "^1.2.20",
+        "@aws-amplify/ui-react-native": "^1.2.29",
         "@azure/core-asynciterator-polyfill": "^1.0.2",
         "@expo/metro-runtime": "~4.0.1",
         "@react-native-async-storage/async-storage": "1.23.1",
@@ -416,17 +416,18 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@aws-amplify/ui": {
-      "version": "5.6.6",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/ui/-/ui-5.6.6.tgz",
-      "integrity": "sha512-kOR9hA7Uzia12qCBZIG+T9axJGIStqxqeVduGyPYdDPdrOd7ppLxX8twns6trjAcIs6PmYl2yBMXVljNmi2grw==",
+      "version": "5.9.0",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/ui/-/ui-5.9.0.tgz",
+      "integrity": "sha512-z0TqsoNN9wQcxdqyxb4CrYPHS+7wXaGkLPNT+zsptWcszBvbabMaXGFb/HZOPzesg6a+cWjYkZpn3WXb+eLpMA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "csstype": "^3.1.1",
         "lodash": "4.17.21",
-        "style-dictionary": "3.7.1",
+        "style-dictionary": "3.9.1",
         "tslib": "2.4.1"
       },
       "peerDependencies": {
-        "aws-amplify": ">= 5.0.1",
+        "aws-amplify": "^5.0.1",
         "xstate": "^4.33.6"
       },
       "peerDependenciesMeta": {
@@ -436,44 +437,47 @@
       }
     },
     "node_modules/@aws-amplify/ui-react-core": {
-      "version": "2.1.25",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/ui-react-core/-/ui-react-core-2.1.25.tgz",
-      "integrity": "sha512-RpZIyyJxeBtYmeJWwQszVPugdGKdmaSiaNU+Gpe3zUdsSF8y1PgWNWhcX0txBRH4b0YMK8CxZkWEejKKJ3sJvQ==",
+      "version": "2.1.34",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/ui-react-core/-/ui-react-core-2.1.34.tgz",
+      "integrity": "sha512-V/uK6TbPzIgEtTpzN9OakdFVwy4tTwVCgHCuUfj8jV4QRmacOolE8kn7/ppguWKPJ27FD6aFi0OMtAQ8GpqD/w==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/ui": "5.6.6",
+        "@aws-amplify/ui": "5.9.0",
         "@xstate/react": "3.0.1",
         "lodash": "4.17.21",
         "xstate": "^4.33.6"
       },
       "peerDependencies": {
-        "aws-amplify": ">= 5.0.1",
+        "aws-amplify": "^5.0.1",
         "react": ">= 16.14.0"
       }
     },
     "node_modules/@aws-amplify/ui-react-core-notifications": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/ui-react-core-notifications/-/ui-react-core-notifications-1.0.2.tgz",
-      "integrity": "sha512-+hLF2vAiz83e382qdr4W5wNXTYMOkN2S2HC0WGAQq43boYSMN4sWCpzmtsKhpLr/PDfl5hjmspFmXV4/VlU+1w==",
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/ui-react-core-notifications/-/ui-react-core-notifications-1.0.11.tgz",
+      "integrity": "sha512-KGFJxFvWUhZ0nOFHlGgYTkDFNinf8OeGGIqeNZP1+zlqZAJc5XV7AqEoi4kFgBy4sFXaxbHvgkPvB4qukTZjAQ==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/ui": "5.6.6",
-        "@aws-amplify/ui-react-core": "2.1.25"
+        "@aws-amplify/ui": "5.9.0",
+        "@aws-amplify/ui-react-core": "2.1.34"
       },
       "peerDependencies": {
-        "aws-amplify": ">= 5.0.1",
+        "aws-amplify": "^5.0.1",
         "react": ">= 16.14.0"
       }
     },
     "node_modules/@aws-amplify/ui-react-native": {
-      "version": "1.2.20",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/ui-react-native/-/ui-react-native-1.2.20.tgz",
-      "integrity": "sha512-cZLi0nOjr/DA+cTI28JRH3qvixrsjOU8ULEfCp1Hi0usNIW25zYnHsmdRSIo1zIf/YntTvY5fuiJWsJALXUI0w==",
+      "version": "1.2.29",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/ui-react-native/-/ui-react-native-1.2.29.tgz",
+      "integrity": "sha512-D7MZIr7r0gKuP/pv7IwQQuLOmh8AZ7aKuoZtX8vfBBZFG8tQcH5QqAufUxYOLxxDSHzwaxg4iyVS7dFUKc5zKA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/ui": "5.6.6",
-        "@aws-amplify/ui-react-core": "2.1.25",
-        "@aws-amplify/ui-react-core-notifications": "1.0.2"
+        "@aws-amplify/ui": "5.9.0",
+        "@aws-amplify/ui-react-core": "2.1.34",
+        "@aws-amplify/ui-react-core-notifications": "1.0.11"
       },
       "peerDependencies": {
-        "aws-amplify": ">= 5.0.1",
+        "aws-amplify": "^5.0.1",
         "react": ">= 16.14.0",
         "react-native": ">= 0.63.4",
         "react-native-safe-area-context": ">= 4.2.5"
@@ -482,7 +486,8 @@
     "node_modules/@aws-amplify/ui/node_modules/tslib": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
-      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "license": "0BSD"
     },
     "node_modules/@aws-crypto/crc32": {
       "version": "2.0.0",
@@ -11675,6 +11680,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@xstate/react/-/react-3.0.1.tgz",
       "integrity": "sha512-/tq/gg92P9ke8J+yDNDBv5/PAxBvXJf2cYyGDByzgtl5wKaxKxzDT82Gj3eWlCJXkrBg4J5/V47//gRJuVH2fA==",
+      "license": "MIT",
       "dependencies": {
         "use-isomorphic-layout-effect": "^1.0.0",
         "use-sync-external-store": "^1.0.0"
@@ -12573,6 +12579,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-4.1.2.tgz",
       "integrity": "sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==",
+      "license": "MIT",
       "dependencies": {
         "pascal-case": "^3.1.2",
         "tslib": "^2.0.3"
@@ -12636,6 +12643,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/capital-case/-/capital-case-1.0.4.tgz",
       "integrity": "sha512-ds37W8CytHgwnhGGTi88pcPyR15qoNkOpYwmMMfnWqqWgESapLqvDx6huFjQ5vqWSn2Z06173XNA7LtMOeUh1A==",
+      "license": "MIT",
       "dependencies": {
         "no-case": "^3.0.4",
         "tslib": "^2.0.3",
@@ -12659,6 +12667,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/change-case/-/change-case-4.1.2.tgz",
       "integrity": "sha512-bSxY2ws9OtviILG1EiY5K7NNxkqg/JnRnFxLtKQ96JaviiIxi7djMrSd0ECT9AC+lttClmYwKw53BWpOMblo7A==",
+      "license": "MIT",
       "dependencies": {
         "camel-case": "^4.1.2",
         "capital-case": "^1.0.4",
@@ -13040,6 +13049,7 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/constant-case/-/constant-case-3.0.4.tgz",
       "integrity": "sha512-I2hSBi7Vvs7BEuJDr5dDHfzb/Ruj3FyvFyh7KLilAjNQw3Be+xgqUBA2W6scVEcL0hL1dwPRtIqEPVUCKkSsyQ==",
+      "license": "MIT",
       "dependencies": {
         "no-case": "^3.0.4",
         "tslib": "^2.0.3",
@@ -13500,6 +13510,7 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.4.tgz",
       "integrity": "sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==",
+      "license": "MIT",
       "dependencies": {
         "no-case": "^3.0.4",
         "tslib": "^2.0.3"
@@ -14848,6 +14859,7 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/header-case/-/header-case-2.0.4.tgz",
       "integrity": "sha512-H/vuk5TEEVZwrR0lp2zed9OCo1uAILMlx0JEMgC26rzyJJ3N1v6XkwHHXJQdR2doSjcGPM6OKPYoJgf0plJ11Q==",
+      "license": "MIT",
       "dependencies": {
         "capital-case": "^1.0.4",
         "tslib": "^2.0.3"
@@ -18026,9 +18038,10 @@
       }
     },
     "node_modules/jsonc-parser": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
-      "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w=="
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
+      "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
+      "license": "MIT"
     },
     "node_modules/jsonfile": {
       "version": "4.0.0",
@@ -18371,6 +18384,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
       "integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
+      "license": "MIT",
       "dependencies": {
         "tslib": "^2.0.3"
       }
@@ -19155,6 +19169,7 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
       "integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
+      "license": "MIT",
       "dependencies": {
         "lower-case": "^2.0.2",
         "tslib": "^2.0.3"
@@ -19435,6 +19450,7 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.4.tgz",
       "integrity": "sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==",
+      "license": "MIT",
       "dependencies": {
         "dot-case": "^3.0.4",
         "tslib": "^2.0.3"
@@ -19499,6 +19515,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.2.tgz",
       "integrity": "sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==",
+      "license": "MIT",
       "dependencies": {
         "no-case": "^3.0.4",
         "tslib": "^2.0.3"
@@ -19508,6 +19525,7 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/path-case/-/path-case-3.0.4.tgz",
       "integrity": "sha512-qO4qCFjXqVTrcbPt/hQfhTQ+VhFsqNKOPtytgNKkKxSoEp3XPUQ8ObFuePylOIok5gjn69ry8XiULxCwot3Wfg==",
+      "license": "MIT",
       "dependencies": {
         "dot-case": "^3.0.4",
         "tslib": "^2.0.3"
@@ -20946,6 +20964,7 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/sentence-case/-/sentence-case-3.0.4.tgz",
       "integrity": "sha512-8LS0JInaQMCRoQ7YUytAo/xUu5W2XnQxV2HI/6uM6U7CITS1RqPElr30V6uIqyMKM9lJGRVFy5/4CuzcixNYSg==",
+      "license": "MIT",
       "dependencies": {
         "no-case": "^3.0.4",
         "tslib": "^2.0.3",
@@ -21105,6 +21124,7 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-3.0.4.tgz",
       "integrity": "sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==",
+      "license": "MIT",
       "dependencies": {
         "dot-case": "^3.0.4",
         "tslib": "^2.0.3"
@@ -21453,16 +21473,17 @@
       "integrity": "sha512-0MP/Cxx5SzeeZ10p/bZI0S6MpgD+yxAhi1BOQ34jgnMXsCq3j1t6tQnZu+KdlL7dvJTLT3g9xN8tl10TqgFMcg=="
     },
     "node_modules/style-dictionary": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/style-dictionary/-/style-dictionary-3.7.1.tgz",
-      "integrity": "sha512-yYU9Z/J8Znj9T9oJVjo8VOYamrOxv0UbBKPjhSt+PharxrhyQCM4RWb71fgEfv2pK9KO8G83/0ChDNQZ1mn0wQ==",
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/style-dictionary/-/style-dictionary-3.9.1.tgz",
+      "integrity": "sha512-odyTC7wMYE4B3VOhc3LW1g0PCz9g+0WZZt5qp8KpWP9POlhw0+8MYiPQYwYfBmu4MEs1qbZ+GHySu4TTjQPH9A==",
+      "license": "Apache-2.0",
       "dependencies": {
         "chalk": "^4.0.0",
         "change-case": "^4.1.2",
         "commander": "^8.3.0",
         "fs-extra": "^10.0.0",
-        "glob": "^7.2.0",
-        "json5": "^2.2.0",
+        "glob": "^10.3.10",
+        "json5": "^2.2.2",
         "jsonc-parser": "^3.0.0",
         "lodash": "^4.17.15",
         "tinycolor2": "^1.4.1"
@@ -21478,6 +21499,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -21488,10 +21510,20 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/style-dictionary/node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
     "node_modules/style-dictionary/node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -21507,6 +21539,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -21517,12 +21550,14 @@
     "node_modules/style-dictionary/node_modules/color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
     },
     "node_modules/style-dictionary/node_modules/commander": {
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
       "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "license": "MIT",
       "engines": {
         "node": ">= 12"
       }
@@ -21531,6 +21566,7 @@
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
       "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -21541,19 +21577,20 @@
       }
     },
     "node_modules/style-dictionary/node_modules/glob": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "license": "ISC",
       "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
       },
-      "engines": {
-        "node": "*"
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -21563,14 +21600,16 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/style-dictionary/node_modules/jsonfile": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
+      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
+      "license": "MIT",
       "dependencies": {
         "universalify": "^2.0.0"
       },
@@ -21578,10 +21617,26 @@
         "graceful-fs": "^4.1.6"
       }
     },
+    "node_modules/style-dictionary/node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/style-dictionary/node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -21590,9 +21645,10 @@
       }
     },
     "node_modules/style-dictionary/node_modules/universalify": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"
       }
@@ -22021,7 +22077,8 @@
     "node_modules/tinycolor2": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.6.0.tgz",
-      "integrity": "sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw=="
+      "integrity": "sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw==",
+      "license": "MIT"
     },
     "node_modules/tmpl": {
       "version": "1.0.5",
@@ -22314,6 +22371,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-2.0.2.tgz",
       "integrity": "sha512-KgdgDGJt2TpuwBUIjgG6lzw2GWFRCW9Qkfkiv0DxqHHLYJHmtmdUIKcZd8rHgFSjopVTlw6ggzCm1b8MFQwikg==",
+      "license": "MIT",
       "dependencies": {
         "tslib": "^2.0.3"
       }
@@ -22322,6 +22380,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-2.0.2.tgz",
       "integrity": "sha512-514ppYHBaKwfJRK/pNC6c/OxfGa0obSnAl106u97Ed0I625Nin96KAjttZF6ZL3e1XLtphxnqrOi9iWgm+u+bg==",
+      "license": "MIT",
       "dependencies": {
         "tslib": "^2.0.3"
       }
@@ -22362,11 +22421,12 @@
       }
     },
     "node_modules/use-isomorphic-layout-effect": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.1.2.tgz",
-      "integrity": "sha512-49L8yCO3iGT/ZF9QttjwLF/ZD9Iwto5LnH5LmEdk/6cFmXddqi2ulF0edxTwjj+7mqvpVVGQWvbXZdn32wRSHA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.2.1.tgz",
+      "integrity": "sha512-tpZZ+EX0gaghDAiFR37hj5MgY6ZN55kLiPkJsKxBMZ6GZdOSPJXiOzPM984oPYZ5AnehYx5WQp1+ME8I/P/pRA==",
+      "license": "MIT",
       "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       },
       "peerDependenciesMeta": {
         "@types/react": {
@@ -22868,9 +22928,10 @@
       "dev": true
     },
     "node_modules/xstate": {
-      "version": "4.38.1",
-      "resolved": "https://registry.npmjs.org/xstate/-/xstate-4.38.1.tgz",
-      "integrity": "sha512-1gBUcFWBj/rv/pRcP2Bedl5sNRGX2d36CaOx9z7fE9uSiHaOEHIWzLg1B853q2xdUHUA9pEiWKjLZ3can4SJaQ==",
+      "version": "4.38.3",
+      "resolved": "https://registry.npmjs.org/xstate/-/xstate-4.38.3.tgz",
+      "integrity": "sha512-SH7nAaaPQx57dx6qvfcIgqKRXIh4L0A1iYEqim4s1u7c9VoCgzZc+63FY90AKU4ZzOC2cfJzTnpO4zK7fCUzzw==",
+      "license": "MIT",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/xstate"
@@ -23326,13 +23387,13 @@
       }
     },
     "@aws-amplify/ui": {
-      "version": "5.6.6",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/ui/-/ui-5.6.6.tgz",
-      "integrity": "sha512-kOR9hA7Uzia12qCBZIG+T9axJGIStqxqeVduGyPYdDPdrOd7ppLxX8twns6trjAcIs6PmYl2yBMXVljNmi2grw==",
+      "version": "5.9.0",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/ui/-/ui-5.9.0.tgz",
+      "integrity": "sha512-z0TqsoNN9wQcxdqyxb4CrYPHS+7wXaGkLPNT+zsptWcszBvbabMaXGFb/HZOPzesg6a+cWjYkZpn3WXb+eLpMA==",
       "requires": {
         "csstype": "^3.1.1",
         "lodash": "4.17.21",
-        "style-dictionary": "3.7.1",
+        "style-dictionary": "3.9.1",
         "tslib": "2.4.1"
       },
       "dependencies": {
@@ -23344,33 +23405,33 @@
       }
     },
     "@aws-amplify/ui-react-core": {
-      "version": "2.1.25",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/ui-react-core/-/ui-react-core-2.1.25.tgz",
-      "integrity": "sha512-RpZIyyJxeBtYmeJWwQszVPugdGKdmaSiaNU+Gpe3zUdsSF8y1PgWNWhcX0txBRH4b0YMK8CxZkWEejKKJ3sJvQ==",
+      "version": "2.1.34",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/ui-react-core/-/ui-react-core-2.1.34.tgz",
+      "integrity": "sha512-V/uK6TbPzIgEtTpzN9OakdFVwy4tTwVCgHCuUfj8jV4QRmacOolE8kn7/ppguWKPJ27FD6aFi0OMtAQ8GpqD/w==",
       "requires": {
-        "@aws-amplify/ui": "5.6.6",
+        "@aws-amplify/ui": "5.9.0",
         "@xstate/react": "3.0.1",
         "lodash": "4.17.21",
         "xstate": "^4.33.6"
       }
     },
     "@aws-amplify/ui-react-core-notifications": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/ui-react-core-notifications/-/ui-react-core-notifications-1.0.2.tgz",
-      "integrity": "sha512-+hLF2vAiz83e382qdr4W5wNXTYMOkN2S2HC0WGAQq43boYSMN4sWCpzmtsKhpLr/PDfl5hjmspFmXV4/VlU+1w==",
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/ui-react-core-notifications/-/ui-react-core-notifications-1.0.11.tgz",
+      "integrity": "sha512-KGFJxFvWUhZ0nOFHlGgYTkDFNinf8OeGGIqeNZP1+zlqZAJc5XV7AqEoi4kFgBy4sFXaxbHvgkPvB4qukTZjAQ==",
       "requires": {
-        "@aws-amplify/ui": "5.6.6",
-        "@aws-amplify/ui-react-core": "2.1.25"
+        "@aws-amplify/ui": "5.9.0",
+        "@aws-amplify/ui-react-core": "2.1.34"
       }
     },
     "@aws-amplify/ui-react-native": {
-      "version": "1.2.20",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/ui-react-native/-/ui-react-native-1.2.20.tgz",
-      "integrity": "sha512-cZLi0nOjr/DA+cTI28JRH3qvixrsjOU8ULEfCp1Hi0usNIW25zYnHsmdRSIo1zIf/YntTvY5fuiJWsJALXUI0w==",
+      "version": "1.2.29",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/ui-react-native/-/ui-react-native-1.2.29.tgz",
+      "integrity": "sha512-D7MZIr7r0gKuP/pv7IwQQuLOmh8AZ7aKuoZtX8vfBBZFG8tQcH5QqAufUxYOLxxDSHzwaxg4iyVS7dFUKc5zKA==",
       "requires": {
-        "@aws-amplify/ui": "5.6.6",
-        "@aws-amplify/ui-react-core": "2.1.25",
-        "@aws-amplify/ui-react-core-notifications": "1.0.2"
+        "@aws-amplify/ui": "5.9.0",
+        "@aws-amplify/ui-react-core": "2.1.34",
+        "@aws-amplify/ui-react-core-notifications": "1.0.11"
       }
     },
     "@aws-crypto/crc32": {
@@ -36964,9 +37025,9 @@
       "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="
     },
     "jsonc-parser": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
-      "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w=="
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
+      "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ=="
     },
     "jsonfile": {
       "version": "4.0.0",
@@ -39455,16 +39516,16 @@
       "integrity": "sha512-0MP/Cxx5SzeeZ10p/bZI0S6MpgD+yxAhi1BOQ34jgnMXsCq3j1t6tQnZu+KdlL7dvJTLT3g9xN8tl10TqgFMcg=="
     },
     "style-dictionary": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/style-dictionary/-/style-dictionary-3.7.1.tgz",
-      "integrity": "sha512-yYU9Z/J8Znj9T9oJVjo8VOYamrOxv0UbBKPjhSt+PharxrhyQCM4RWb71fgEfv2pK9KO8G83/0ChDNQZ1mn0wQ==",
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/style-dictionary/-/style-dictionary-3.9.1.tgz",
+      "integrity": "sha512-odyTC7wMYE4B3VOhc3LW1g0PCz9g+0WZZt5qp8KpWP9POlhw0+8MYiPQYwYfBmu4MEs1qbZ+GHySu4TTjQPH9A==",
       "requires": {
         "chalk": "^4.0.0",
         "change-case": "^4.1.2",
         "commander": "^8.3.0",
         "fs-extra": "^10.0.0",
-        "glob": "^7.2.0",
-        "json5": "^2.2.0",
+        "glob": "^10.3.10",
+        "json5": "^2.2.2",
         "jsonc-parser": "^3.0.0",
         "lodash": "^4.17.15",
         "tinycolor2": "^1.4.1"
@@ -39476,6 +39537,14 @@
           "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
           "requires": {
             "color-convert": "^2.0.1"
+          }
+        },
+        "brace-expansion": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+          "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+          "requires": {
+            "balanced-match": "^1.0.0"
           }
         },
         "chalk": {
@@ -39516,16 +39585,16 @@
           }
         },
         "glob": {
-          "version": "7.2.3",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-          "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+          "version": "10.5.0",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+          "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
           "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.1.1",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "foreground-child": "^3.1.0",
+            "jackspeak": "^3.1.2",
+            "minimatch": "^9.0.4",
+            "minipass": "^7.1.2",
+            "package-json-from-dist": "^1.0.0",
+            "path-scurry": "^1.11.1"
           }
         },
         "has-flag": {
@@ -39534,12 +39603,20 @@
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
         },
         "jsonfile": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-          "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
+          "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
           "requires": {
             "graceful-fs": "^4.1.6",
             "universalify": "^2.0.0"
+          }
+        },
+        "minimatch": {
+          "version": "9.0.5",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+          "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+          "requires": {
+            "brace-expansion": "^2.0.1"
           }
         },
         "supports-color": {
@@ -39551,9 +39628,9 @@
           }
         },
         "universalify": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-          "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ=="
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+          "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw=="
         }
       }
     },
@@ -40103,9 +40180,9 @@
       }
     },
     "use-isomorphic-layout-effect": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.1.2.tgz",
-      "integrity": "sha512-49L8yCO3iGT/ZF9QttjwLF/ZD9Iwto5LnH5LmEdk/6cFmXddqi2ulF0edxTwjj+7mqvpVVGQWvbXZdn32wRSHA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.2.1.tgz",
+      "integrity": "sha512-tpZZ+EX0gaghDAiFR37hj5MgY6ZN55kLiPkJsKxBMZ6GZdOSPJXiOzPM984oPYZ5AnehYx5WQp1+ME8I/P/pRA==",
       "requires": {}
     },
     "use-latest-callback": {
@@ -40477,9 +40554,9 @@
       "dev": true
     },
     "xstate": {
-      "version": "4.38.1",
-      "resolved": "https://registry.npmjs.org/xstate/-/xstate-4.38.1.tgz",
-      "integrity": "sha512-1gBUcFWBj/rv/pRcP2Bedl5sNRGX2d36CaOx9z7fE9uSiHaOEHIWzLg1B853q2xdUHUA9pEiWKjLZ3can4SJaQ=="
+      "version": "4.38.3",
+      "resolved": "https://registry.npmjs.org/xstate/-/xstate-4.38.3.tgz",
+      "integrity": "sha512-SH7nAaaPQx57dx6qvfcIgqKRXIh4L0A1iYEqim4s1u7c9VoCgzZc+63FY90AKU4ZzOC2cfJzTnpO4zK7fCUzzw=="
     },
     "y18n": {
       "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "ios": "expo run:ios",
     "web": "expo start --web",
     "test": "jest --watch --testTimeout=60000",
-    "test:ci": "jest --testTimeout=60000",
+    "test:ci": "jest --testTimeout=120000",
     "test:debug": "node --inspect-brk ./node_modules/jest/bin/jest.js --runInBand --testTimeout=100000000"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@aws-amplify/datastore-storage-adapter": "^2.0.42",
-    "@aws-amplify/ui-react-native": "^1.2.20",
+    "@aws-amplify/ui-react-native": "^1.2.29",
     "@azure/core-asynciterator-polyfill": "^1.0.2",
     "@expo/metro-runtime": "~4.0.1",
     "@react-native-async-storage/async-storage": "1.23.1",


### PR DESCRIPTION
This updates the @aws-amplify/ui-react-native component to a newer version.

It doesn't fix the disabled button issue but does show a warning about an invalid email, which could at least hint the user towards changing the email address to trigger proper validation.

The newest version of the package requries aws-amplify v6. this may have a better fix but migration needs to be done first.